### PR TITLE
UserManager now serializes an empty ArrayList<Event> to events.txt upon creating an account

### DIFF
--- a/src/main/java/managers/UserManager.java
+++ b/src/main/java/managers/UserManager.java
@@ -1,6 +1,7 @@
 package managers;
 
 import users.User;
+import events.Event;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -60,8 +61,13 @@ public class UserManager {
         pw.write(password);
         pw.flush();
         pw.close();
-        File file = new File(USER_DIRECTORY_PATH + username + "/events.txt");
-        if(!file.createNewFile()){ throw new Exception("Could not create new file. Something went wrong.");}
+
+        ArrayList<Event> empty_events = new ArrayList<>();
+        FileOutputStream fos = new FileOutputStream(USER_DIRECTORY_PATH + username + "/events.txt");
+        ObjectOutputStream oos = new ObjectOutputStream(fos);
+        oos.writeObject(empty_events);
+        oos.close();
+        fos.close();
         this.users = USER_DIRECTORY.listFiles();
         /*
          * the list of users has to be updated again after creating a new account; login is separate from account


### PR DESCRIPTION
Update:
UserManager now serializes an empty ArrayList<Event> to events.txt upon creating an account.

Could not think of a better way to implement this without reworking how it interacts with EventManager.

IMPORTANT:
Our current existing users (i.e john_doe, jane_doe) will NOT work and any test Users we want to use need to be created through the system.